### PR TITLE
Added a check for exactly 0 minutes or 30 minutes past the hour, and adding one minute to get more accurate results.

### DIFF
--- a/Backend/Location.cs
+++ b/Backend/Location.cs
@@ -18,7 +18,7 @@ public class Location(string name)
             if (
                 entry.Day == day &&
                 entry.TeachingWeeks.Contains(teachingWeek) &&
-                entry.StartTime < time &&
+                entry.StartTime <= time &&
                 entry.EndTime > time)
             {
                 return false;


### PR DESCRIPTION
Before, the results weren't quite right if you selected an exact time with 0 or 30 minutes past the hour, as that's then when the events exactly begin and end. I've added a check for this and we'll add one minute, meaning that the results for the next block of classes will always be shown, which I think is the most useful way of doing it.